### PR TITLE
Feat: Añadir visualización de pedidos a la interfaz web

### DIFF
--- a/gestion_medicamentos/web/templates/base.html
+++ b/gestion_medicamentos/web/templates/base.html
@@ -27,10 +27,9 @@
         <h1>Gestor de Medicamentos Caseros</h1>
         <nav>
             <ul>
-                <li><a href="/">Inicio</a></li>
-                <li><a href="/medicamentos/">Medicamentos</a></li>
-                {# <li><a href="/pedidos/">Pedidos</a></li> #}
-                {# Añadir más enlaces de navegación aquí cuando las rutas existan y se llamen así #}
+                <li><a href="{{ url_for('root') }}">Inicio</a></li>
+                <li><a href="{{ url_for('listar_todos_medicamentos') }}">Medicamentos</a></li>
+                <li><a href="{{ url_for('listar_todos_pedidos') }}">Pedidos</a></li>
             </ul>
         </nav>
     </header>

--- a/gestion_medicamentos/web/templates/detalle_pedido.html
+++ b/gestion_medicamentos/web/templates/detalle_pedido.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block title %}Detalle Pedido #{{ pedido.id }} - Gestor de Medicamentos{% endblock %}
+
+{% block content %}
+<h2>Detalle del Pedido #{{ pedido.id }}</h2>
+
+<p><strong>ID Pedido:</strong> {{ pedido.id }}</p>
+<p><strong>Fecha del Pedido:</strong> {{ pedido.fecha_pedido.strftime('%d/%m/%Y') }}</p>
+<p><strong>Proveedor:</strong> {{ pedido.proveedor if pedido.proveedor else 'N/A' }}</p>
+<p><strong>Estado:</strong> {{ pedido.estado.value }}</p>
+<p><strong>Costo Total Calculado:</strong> {{ "%.2f" | format(costo_total) }}</p>
+
+<h3>Ítems del Pedido</h3>
+{% if detalles_pedido %}
+    <table>
+        <thead>
+            <tr>
+                <th>ID Detalle</th>
+                <th>Medicamento (ID)</th>
+                <th>Nombre Medicamento</th>
+                <th>Cajas Pedidas</th>
+                <th>Precio Unitario/Caja</th>
+                <th>Subtotal</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for detalle in detalles_pedido %}
+            <tr>
+                <td>{{ detalle.id }}</td>
+                <td>{{ detalle.medicamento_id }}</td>
+                <td>{{ detalle.medicamento.nombre if detalle.medicamento else 'Desconocido' }}</td> {# Asume que el objeto medicamento está cargado o se carga aquí #}
+                <td>{{ detalle.cantidad_cajas_pedidas }}</td>
+                <td>{{ "%.2f" | format(detalle.precio_unitario_compra_caja) if detalle.precio_unitario_compra_caja is not none else 'N/A' }}</td>
+                <td>{{ "%.2f" | format(detalle.subtotal_detalle) }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% else %}
+    <p>Este pedido no tiene ítems registrados.</p>
+{% endif %}
+
+<p style="margin-top: 20px;"><a href="{{ url_for('listar_todos_pedidos') }}">Volver a la lista de pedidos</a></p>
+{% endblock %}

--- a/gestion_medicamentos/web/templates/lista_medicamentos.html
+++ b/gestion_medicamentos/web/templates/lista_medicamentos.html
@@ -5,7 +5,7 @@
 {% block content %}
 <h2>Listado de Medicamentos</h2>
 
-{% if medicamentos %}
+{% if medicamentos_info %} {# <--- Cambio aquí: de 'medicamentos' a 'medicamentos_info' #}
     <table>
         <thead>
             <tr>

--- a/gestion_medicamentos/web/templates/lista_pedidos.html
+++ b/gestion_medicamentos/web/templates/lista_pedidos.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block title %}Lista de Pedidos - Gestor de Medicamentos{% endblock %}
+
+{% block content %}
+<h2>Listado de Pedidos</h2>
+
+{% if pedidos_info %}
+    <table>
+        <thead>
+            <tr>
+                <th>ID Pedido</th>
+                <th>Fecha Pedido</th>
+                <th>Proveedor</th>
+                <th>Estado</th>
+                <th>Costo Total</th>
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for info in pedidos_info %}
+            <tr>
+                <td>{{ info.pedido.id }}</td>
+                <td>{{ info.pedido.fecha_pedido.strftime('%d/%m/%Y') }}</td>
+                <td>{{ info.pedido.proveedor if info.pedido.proveedor else 'N/A' }}</td>
+                <td>{{ info.pedido.estado.value }}</td>
+                <td>{{ "%.2f" | format(info.costo_total) }}</td>
+                <td>
+                    <a href="/pedidos/{{ info.pedido.id }}/">Ver Detalles</a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% else %}
+    <p>No hay pedidos registrados en la base de datos.</p>
+{% endif %}
+
+{# <p><a href="/pedidos/nuevo/">Crear Nuevo Pedido</a> (Funcionalidad futura)</p> #}
+{% endblock %}


### PR DESCRIPTION
Se amplía la interfaz web FastAPI para incluir la visualización de pedidos y sus detalles.

Nuevas funcionalidades:
- Ruta y plantilla para listar todos los pedidos (`/pedidos/`):
    - Muestra una tabla con ID, fecha, proveedor, estado y costo total de cada pedido.
    - Enlace para ver detalles de cada pedido.
- Ruta y plantilla para ver detalles de un pedido específico (`/pedidos/{pedido_id}/`):
    - Muestra información general del pedido.
    - Muestra una tabla de los ítems del pedido (medicamento, cantidad, precio, subtotal).
- Actualizada la plantilla base (`base.html`) para incluir un enlace de navegación funcional a la sección de Pedidos usando `url_for`.

Correcciones incluidas en este conjunto de cambios:
- Corregida la discrepancia de nombres de variable en `lista_medicamentos.html` para asegurar que los medicamentos se muestren correctamente.
- Eliminados logs de depuración de la ruta de listar medicamentos en `main_web.py`.