### PR TITLE
Feat: CRUD web para encabezado de Pedidos

### DIFF
--- a/gestion_medicamentos/web/templates/confirmar_eliminacion_pedido.html
+++ b/gestion_medicamentos/web/templates/confirmar_eliminacion_pedido.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block title %}Confirmar Eliminación Pedido - Gestor de Medicamentos{% endblock %}
+
+{% block content %}
+<h2>Confirmar Eliminación de Pedido</h2>
+
+{% if pedido %}
+    <p>¿Está seguro de que desea eliminar el siguiente pedido?</p>
+    <p><strong>ID Pedido:</strong> {{ pedido.id }}</p>
+    <p><strong>Fecha:</strong> {{ pedido.fecha_pedido.strftime('%d/%m/%Y') }}</p>
+    <p><strong>Proveedor:</strong> {{ pedido.proveedor if pedido.proveedor else 'N/A' }}</p>
+    <p><strong>Estado:</strong> {{ pedido.estado.value }}</p>
+
+    <p style="color: red; font-weight: bold;">Esta acción no se puede deshacer y también eliminará todos los ítems (detalles) asociados a este pedido.</p>
+
+    <form method="post" action="{{ url_for('eliminar_pedido_submit', pedido_id=pedido.id) }}" style="margin-top: 20px;">
+        <button type="submit" style="background-color: #d9534f; color: white; border: none; padding: 10px 15px; cursor: pointer; border-radius: 4px;">Sí, Eliminar Definitivamente</button>
+        <a href="{{ url_for('detalle_pedido_ruta', pedido_id=pedido.id) }}" style="margin-left: 10px; text-decoration: none; background-color: #ccc; color: #333; padding: 10px 15px; border-radius: 4px;">Cancelar</a>
+    </form>
+{% else %}
+    <p>No se ha especificado un pedido para eliminar o no se encontró.</p>
+    <p><a href="{{ url_for('listar_todos_pedidos') }}">Volver a la lista de pedidos</a></p>
+{% endif %}
+
+{% endblock %}

--- a/gestion_medicamentos/web/templates/detalle_pedido.html
+++ b/gestion_medicamentos/web/templates/detalle_pedido.html
@@ -41,5 +41,11 @@
     <p>Este pedido no tiene ítems registrados.</p>
 {% endif %}
 
+<div style="margin-top: 30px;">
+    <a href="{{ url_for('editar_pedido_form', pedido_id=pedido.id) }}" style="background-color: #f0ad4e; color: white; padding: 10px 15px; text-decoration: none; border-radius: 4px; margin-right: 10px;">Editar Encabezado Pedido</a>
+    <a href="{{ url_for('eliminar_pedido_confirm_form', pedido_id=pedido.id) }}" style="background-color: #d9534f; color: white; padding: 10px 15px; text-decoration: none; border-radius: 4px;">Eliminar Pedido</a>
+    {# Aquí podríamos añadir un enlace para "Añadir Ítem al Pedido" en el futuro #}
+</div>
+
 <p style="margin-top: 20px;"><a href="{{ url_for('listar_todos_pedidos') }}">Volver a la lista de pedidos</a></p>
 {% endblock %}

--- a/gestion_medicamentos/web/templates/form_pedido.html
+++ b/gestion_medicamentos/web/templates/form_pedido.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+
+{% block title %}{{ form_title }} - Gestor de Medicamentos{% endblock %}
+
+{% block content %}
+<h2>{{ form_title }}</h2>
+
+<form method="post" action="{{ form_action }}">
+    <div>
+        <label for="fecha_pedido">Fecha del Pedido (YYYY-MM-DD):</label>
+        {# El input de tipo 'date' usualmente espera YYYY-MM-DD para el valor #}
+        <input type="date" id="fecha_pedido" name="fecha_pedido"
+               value="{{ pedido.fecha_pedido.strftime('%Y-%m-%d') if pedido and pedido.fecha_pedido else today_date_iso }}"
+               required>
+        <small>Si se deja vacío, se usará la fecha actual al guardar (para creación).</small>
+    </div>
+
+    <div style="margin-top: 10px;">
+        <label for="proveedor">Proveedor (Opcional):</label>
+        <input type="text" id="proveedor" name="proveedor"
+               value="{{ pedido.proveedor if pedido and pedido.proveedor is not none else '' }}">
+    </div>
+
+    <div style="margin-top: 10px;">
+        <label for="estado">Estado del Pedido:</label>
+        <select id="estado" name="estado" required>
+            {% for estado_val in estados_posibles %}
+            <option value="{{ estado_val.name }}" {% if pedido and pedido.estado and pedido.estado.name == estado_val.name %}selected{% elif not pedido and estado_val.name == 'PENDIENTE' %}selected{% endif %}>
+                {{ estado_val.value }}
+            </option>
+            {% endfor %}
+        </select>
+    </div>
+
+    {# Aquí no se gestionan los ítems del pedido en este paso del plan #}
+    {# En una fase posterior, se podría añadir una sección para ítems #}
+
+    <div style="margin-top: 20px;">
+        <button type="submit">Guardar Pedido</button>
+        <a href="{{ url_for('listar_todos_pedidos') }}" style="margin-left: 10px;">Cancelar</a>
+    </div>
+</form>
+
+{% if errors %}
+    <div style="margin-top: 20px; color: red;">
+        <h4>Errores de validación:</h4>
+        <ul>
+            {% for error in errors %}
+                <li>
+                    {% if error.loc|length > 1 %}
+                        {{ error.loc[1] }}
+                    {% elif error.loc %}
+                        {{ error.loc[0] }}
+                    {% else %}
+                        General
+                    {% endif %}
+                    : {{ error.msg }}
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+{% endif %}
+
+{% endblock %}

--- a/gestion_medicamentos/web/templates/lista_pedidos.html
+++ b/gestion_medicamentos/web/templates/lista_pedidos.html
@@ -26,7 +26,9 @@
                 <td>{{ info.pedido.estado.value }}</td>
                 <td>{{ "%.2f" | format(info.costo_total) }}</td>
                 <td>
-                    <a href="/pedidos/{{ info.pedido.id }}/">Ver Detalles</a>
+                    <a href="{{ url_for('detalle_pedido_ruta', pedido_id=info.pedido.id) }}">Ver Detalles</a> |
+                    <a href="{{ url_for('editar_pedido_form', pedido_id=info.pedido.id) }}">Editar Encabezado</a> |
+                    <a href="{{ url_for('eliminar_pedido_confirm_form', pedido_id=info.pedido.id) }}">Eliminar</a>
                 </td>
             </tr>
             {% endfor %}
@@ -36,5 +38,7 @@
     <p>No hay pedidos registrados en la base de datos.</p>
 {% endif %}
 
-{# <p><a href="/pedidos/nuevo/">Crear Nuevo Pedido</a> (Funcionalidad futura)</p> #}
+<p style="margin-top: 20px;">
+    <a href="{{ url_for('crear_pedido_form') }}" style="background-color: #5cb85c; color: white; padding: 10px 15px; text-decoration: none; border-radius: 4px;">Crear Nuevo Pedido</a>
+</p>
 {% endblock %}


### PR DESCRIPTION
Se implementa la funcionalidad CRUD (Crear, Leer, Actualizar, Eliminar) para el encabezado de los Pedidos a través de la interfaz web FastAPI. La gestión de los ítems (DetallesPedido) se abordará en un paso posterior.

Funcionalidades añadidas:
- Actualizados Schemas Pydantic para Pedido (`PedidoBase`, `PedidoCreate`, `PedidoUpdate`, `PedidoSchema`) y placeholders para `DetallePedido`.
- Creada plantilla de formulario `form_pedido.html` para crear y editar los datos del encabezado del pedido (fecha, proveedor, estado).
- Implementadas rutas GET y POST para crear nuevos pedidos (encabezado) (`/pedidos/nuevo/`), con validación y redirección al detalle del pedido.
- Implementadas rutas GET y POST para editar encabezados de pedidos existentes (`/pedidos/{pedido_id}/editar/`), con pre-rellenado y validación.
- Creada plantilla `confirmar_eliminacion_pedido.html`.
- Implementadas rutas GET y POST para eliminar pedidos completos (`/pedidos/{pedido_id}/eliminar/`) con página de confirmación.
- Actualizadas plantillas `lista_pedidos.html` y `detalle_pedido.html` para incluir enlaces/botones para las nuevas acciones CRUD de pedidos.