### PR TITLE
Feat: Añadir y eliminar ítems de pedidos en interfaz web

### DIFF
--- a/gestion_medicamentos/app/schemas.py
+++ b/gestion_medicamentos/app/schemas.py
@@ -57,8 +57,8 @@ class DetallePedidoCreate(DetallePedidoBase):
 
 class DetallePedidoSchema(DetallePedidoBase):
     id: int
-    pedido_id: int # Añadido para referencia
-    # medicamento: MedicamentoSchema # Descomentar si es necesario en respuestas
+    pedido_id: int
+    medicamento: MedicamentoSchema # Para mostrar info del medicamento en el detalle del pedido
 
     class Config:
         orm_mode = True

--- a/gestion_medicamentos/main_web.py
+++ b/gestion_medicamentos/main_web.py
@@ -7,7 +7,8 @@ from fastapi.responses import RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 from pydantic import ValidationError
-from typing import Optional
+from typing import Optional, List
+from datetime import date as py_date # Renombrar para evitar conflicto con models.Date
 
 # Añadir el directorio de la aplicación al sys.path
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -25,6 +26,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 templates_dir = os.path.join(current_dir, "web", "templates")
 templates = Jinja2Templates(directory=templates_dir)
 
+# --- Dependencia de Sesión de BD ---
 def get_db_session_fastapi():
     db = None
     try:
@@ -34,10 +36,12 @@ def get_db_session_fastapi():
         if db:
             db.close()
 
+# --- Rutas Principales ---
 @app.get("/", name="root")
 async def root(request: Request):
     return templates.TemplateResponse("index.html", {"request": request, "title": "Página de Inicio"})
 
+# --- Rutas para Medicamentos ---
 @app.get("/medicamentos/", name="listar_todos_medicamentos")
 async def listar_todos_medicamentos(request: Request, db: Session = Depends(get_db_session_fastapi)):
     medicamentos = crud.obtener_medicamentos(db, limit=1000)
@@ -46,43 +50,30 @@ async def listar_todos_medicamentos(request: Request, db: Session = Depends(get_
         stock_total = crud.calcular_stock_total_unidades(db, med.id)
         vencimiento_proximo = crud.calcular_fecha_vencimiento_proxima(db, med.id)
         medicamentos_info.append({
-            "medicamento": med,
-            "stock_total": stock_total,
-            "vencimiento_proximo": vencimiento_proximo
+            "medicamento": med, "stock_total": stock_total, "vencimiento_proximo": vencimiento_proximo
         })
     return templates.TemplateResponse("lista_medicamentos.html", {
-        "request": request,
-        "medicamentos_info": medicamentos_info,
-        "title": "Lista de Medicamentos"
+        "request": request, "medicamentos_info": medicamentos_info, "title": "Lista de Medicamentos"
     })
 
-# --- CRUD Medicamentos ---
 @app.get("/medicamentos/nuevo/", name="crear_medicamento_form")
 async def crear_medicamento_form(request: Request):
     return templates.TemplateResponse("form_medicamento.html", {
-        "request": request,
-        "form_title": "Añadir Nuevo Medicamento",
+        "request": request, "form_title": "Añadir Nuevo Medicamento",
         "form_action": request.url_for("crear_medicamento_submit"),
-        "medicamento": None,
-        "errors": None
+        "medicamento": None, "errors": None
     })
 
 @app.post("/medicamentos/nuevo/", name="crear_medicamento_submit")
 async def crear_medicamento_submit(
-    request: Request,
-    nombre: str = Form(...),
-    marca: Optional[str] = Form(None),
-    unidades_por_caja: int = Form(...),
-    precio_por_caja_referencia: Optional[float] = Form(None),
+    request: Request, nombre: str = Form(...), marca: Optional[str] = Form(None),
+    unidades_por_caja: int = Form(...), precio_por_caja_referencia: Optional[float] = Form(None),
     db: Session = Depends(get_db_session_fastapi)
 ):
     errors = []
     form_data_repop = {"nombre": nombre, "marca": marca, "unidades_por_caja": unidades_por_caja, "precio_por_caja_referencia": precio_por_caja_referencia}
     try:
-        medicamento_data = schemas.MedicamentoCreate(
-            nombre=nombre, marca=marca, unidades_por_caja=unidades_por_caja,
-            precio_por_caja_referencia=precio_por_caja_referencia
-        )
+        medicamento_data = schemas.MedicamentoCreate(**form_data_repop)
     except ValidationError as e:
         return templates.TemplateResponse("form_medicamento.html", {
             "request": request, "form_title": "Añadir Nuevo Medicamento",
@@ -90,8 +81,7 @@ async def crear_medicamento_submit(
             "medicamento": form_data_repop, "errors": e.errors()
         }, status_code=422)
 
-    db_medicamento_existente = crud.obtener_medicamento_por_nombre(db, nombre=medicamento_data.nombre)
-    if db_medicamento_existente:
+    if crud.obtener_medicamento_por_nombre(db, nombre=medicamento_data.nombre):
         errors.append({"loc": ["nombre"], "msg": "Ya existe un medicamento con este nombre."})
         return templates.TemplateResponse("form_medicamento.html", {
             "request": request, "form_title": "Añadir Nuevo Medicamento",
@@ -100,12 +90,10 @@ async def crear_medicamento_submit(
         }, status_code=400)
 
     try:
-        crud.crear_medicamento(db=db, nombre=medicamento_data.nombre, marca=medicamento_data.marca,
-                               unidades_por_caja=medicamento_data.unidades_por_caja,
-                               precio_referencia=medicamento_data.precio_por_caja_referencia)
+        crud.crear_medicamento(db=db, **medicamento_data.dict())
         return RedirectResponse(url=request.url_for("listar_todos_medicamentos"), status_code=303)
     except Exception as e:
-        errors.append({"loc": ["general"], "msg": f"Error inesperado al guardar el medicamento: {e}"})
+        errors.append({"loc": ["general"], "msg": f"Error inesperado: {e}"})
         return templates.TemplateResponse("form_medicamento.html", {
             "request": request, "form_title": "Añadir Nuevo Medicamento",
             "form_action": request.url_for("crear_medicamento_submit"),
@@ -116,7 +104,7 @@ async def crear_medicamento_submit(
 async def editar_medicamento_form(request: Request, medicamento_id: int, db: Session = Depends(get_db_session_fastapi)):
     medicamento = crud.obtener_medicamento(db, medicamento_id=medicamento_id)
     if not medicamento:
-        raise HTTPException(status_code=404, detail=f"Medicamento con ID {medicamento_id} no encontrado")
+        raise HTTPException(status_code=404, detail="Medicamento no encontrado")
     return templates.TemplateResponse("form_medicamento.html", {
         "request": request, "form_title": f"Editar Medicamento: {medicamento.nombre}",
         "form_action": request.url_for("editar_medicamento_submit", medicamento_id=medicamento_id),
@@ -133,15 +121,11 @@ async def editar_medicamento_submit(
     errors = []
     medicamento_original = crud.obtener_medicamento(db, medicamento_id=medicamento_id)
     if not medicamento_original:
-        raise HTTPException(status_code=404, detail=f"Medicamento con ID {medicamento_id} no encontrado para actualizar")
+        raise HTTPException(status_code=404, detail="Medicamento no encontrado para actualizar")
 
     form_data_repop = {"id": medicamento_id, "nombre": nombre, "marca": marca, "unidades_por_caja": unidades_por_caja, "precio_por_caja_referencia": precio_por_caja_referencia}
-
     try:
-        medicamento_data_update = schemas.MedicamentoUpdate(
-            nombre=nombre, marca=marca, unidades_por_caja=unidades_por_caja,
-            precio_por_caja_referencia=precio_por_caja_referencia
-        )
+        medicamento_data_update = schemas.MedicamentoUpdate(**form_data_repop)
     except ValidationError as e:
         return templates.TemplateResponse("form_medicamento.html", {
             "request": request, "form_title": f"Editar Medicamento: {medicamento_original.nombre}",
@@ -149,8 +133,8 @@ async def editar_medicamento_submit(
             "medicamento": form_data_repop, "errors": e.errors()
         }, status_code=422)
 
-    if medicamento_data_update.nombre and medicamento_data_update.nombre.lower() != medicamento_original.nombre.lower():
-        db_medicamento_existente = crud.obtener_medicamento_por_nombre(db, nombre=medicamento_data_update.nombre)
+    if nombre.lower() != medicamento_original.nombre.lower():
+        db_medicamento_existente = crud.obtener_medicamento_por_nombre(db, nombre=nombre)
         if db_medicamento_existente and db_medicamento_existente.id != medicamento_id:
             errors.append({"loc": ["nombre"], "msg": "Ya existe otro medicamento con este nombre."})
             return templates.TemplateResponse("form_medicamento.html", {
@@ -169,7 +153,7 @@ async def editar_medicamento_submit(
         crud.actualizar_medicamento(db, medicamento_id=medicamento_id, datos_actualizacion=update_data_dict)
         return RedirectResponse(url=request.url_for("detalle_medicamento", medicamento_id=medicamento_id), status_code=303)
     except Exception as e:
-        errors.append({"loc": ["general"], "msg": f"Error inesperado al actualizar el medicamento: {e}"})
+        errors.append({"loc": ["general"], "msg": f"Error inesperado: {e}"})
         return templates.TemplateResponse("form_medicamento.html", {
             "request": request, "form_title": f"Editar Medicamento: {medicamento_original.nombre}",
             "form_action": request.url_for("editar_medicamento_submit", medicamento_id=medicamento_id),
@@ -180,16 +164,15 @@ async def editar_medicamento_submit(
 async def eliminar_medicamento_confirm_form(request: Request, medicamento_id: int, db: Session = Depends(get_db_session_fastapi)):
     medicamento = crud.obtener_medicamento(db, medicamento_id=medicamento_id)
     if not medicamento:
-        raise HTTPException(status_code=404, detail=f"Medicamento con ID {medicamento_id} no encontrado")
+        raise HTTPException(status_code=404, detail="Medicamento no encontrado")
     return templates.TemplateResponse("confirmar_eliminacion_medicamento.html", {
         "request": request, "medicamento": medicamento, "title": f"Confirmar Eliminación: {medicamento.nombre}"
     })
 
 @app.post("/medicamentos/{medicamento_id}/eliminar/", name="eliminar_medicamento_submit")
 async def eliminar_medicamento_submit(request: Request, medicamento_id: int, db: Session = Depends(get_db_session_fastapi)):
-    medicamento = crud.obtener_medicamento(db, medicamento_id=medicamento_id)
-    if not medicamento:
-        raise HTTPException(status_code=404, detail=f"Medicamento con ID {medicamento_id} no encontrado para eliminar")
+    if not crud.obtener_medicamento(db, medicamento_id=medicamento_id):
+        raise HTTPException(status_code=404, detail="Medicamento no encontrado para eliminar")
     try:
         crud.eliminar_medicamento(db, medicamento_id=medicamento_id)
         return RedirectResponse(url=request.url_for("listar_todos_medicamentos"), status_code=303)
@@ -204,14 +187,13 @@ async def detalle_medicamento(request: Request, medicamento_id: int, db: Session
     lotes = crud.obtener_lotes_por_medicamento(db, medicamento_id=medicamento_id, solo_activos=False)
     stock_total = crud.calcular_stock_total_unidades(db, medicamento_id=medicamento_id)
     vencimiento_proximo = crud.calcular_fecha_vencimiento_proxima(db, medicamento_id=medicamento_id)
-    from datetime import date as py_date
     return templates.TemplateResponse("detalle_medicamento.html", {
         "request": request, "medicamento": medicamento, "lotes": lotes,
         "stock_total": stock_total, "vencimiento_proximo": vencimiento_proximo,
         "today_date": py_date.today(), "title": f"Detalle: {medicamento.nombre}"
     })
 
-# --- Rutas para Pedidos (Visualización y CRUD de encabezado) ---
+# --- Rutas para Pedidos ---
 @app.get("/pedidos/", name="listar_todos_pedidos")
 async def listar_todos_pedidos(request: Request, db: Session = Depends(get_db_session_fastapi)):
     pedidos = crud.obtener_pedidos(db, limit=1000)
@@ -223,7 +205,6 @@ async def listar_todos_pedidos(request: Request, db: Session = Depends(get_db_se
 
 @app.get("/pedidos/nuevo/", name="crear_pedido_form")
 async def crear_pedido_form(request: Request):
-    from datetime import date as py_date
     return templates.TemplateResponse("form_pedido.html", {
         "request": request, "form_title": "Crear Nuevo Pedido",
         "form_action": request.url_for("crear_pedido_submit"), "pedido": None,
@@ -233,50 +214,40 @@ async def crear_pedido_form(request: Request):
 
 @app.post("/pedidos/nuevo/", name="crear_pedido_submit")
 async def crear_pedido_submit(
-    request: Request,
-    fecha_pedido_str: Optional[str] = Form(None, alias="fecha_pedido"),
-    proveedor: Optional[str] = Form(None),
-    estado_str: str = Form(schemas.EstadoPedidoEnum.PENDIENTE.name, alias="estado"), # Recibido como string
+    request: Request, fecha_pedido_str: Optional[str] = Form(None, alias="fecha_pedido"),
+    proveedor: Optional[str] = Form(None), estado_str: str = Form(schemas.EstadoPedidoEnum.PENDIENTE.name, alias="estado"),
     db: Session = Depends(get_db_session_fastapi)
 ):
     errors = []
-    from datetime import date as py_date
     fecha_pedido_obj: Optional[py_date] = None
     form_data_repop = {"proveedor": proveedor, "estado_str_form": estado_str, "fecha_pedido_str_form": fecha_pedido_str if fecha_pedido_str else py_date.today().isoformat()}
 
     if fecha_pedido_str:
-        try:
-            fecha_pedido_obj = py_date.fromisoformat(fecha_pedido_str)
-        except ValueError:
-            errors.append({"loc": ["fecha_pedido"], "msg": "Formato de fecha inválido. Use YYYY-MM-DD."})
-    else:
-        fecha_pedido_obj = py_date.today()
+        try: fecha_pedido_obj = py_date.fromisoformat(fecha_pedido_str)
+        except ValueError: errors.append({"loc": ["fecha_pedido"], "msg": "Formato de fecha inválido. Use YYYY-MM-DD."})
+    else: fecha_pedido_obj = py_date.today()
 
     if errors:
         return templates.TemplateResponse("form_pedido.html", {
-            "request": request, "form_title": "Crear Nuevo Pedido",
-            "form_action": request.url_for("crear_pedido_submit"),
-            "pedido": form_data_repop,
-            "estados_posibles": list(schemas.EstadoPedidoEnum),
+            "request": request, "form_title": "Crear Nuevo Pedido", "form_action": request.url_for("crear_pedido_submit"),
+            "pedido": form_data_repop, "estados_posibles": list(schemas.EstadoPedidoEnum),
             "today_date_iso": py_date.today().isoformat(), "errors": errors
         }, status_code=422)
 
     try:
-        estado_enum_val = schemas.EstadoPedidoEnum[estado_str.upper()] # Convertir string a Enum (usar .upper() para más robustez)
+        estado_enum_val = schemas.EstadoPedidoEnum[estado_str.upper()]
         pedido_data = schemas.PedidoCreate(fecha_pedido=fecha_pedido_obj, proveedor=proveedor, estado=estado_enum_val)
     except KeyError:
         errors.append({"loc": ["estado"], "msg": "Valor de estado no válido."})
         return templates.TemplateResponse("form_pedido.html", {
-            "request": request, "form_title": "Crear Nuevo Pedido",
-            "form_action": request.url_for("crear_pedido_submit"), "pedido": form_data_repop,
-            "estados_posibles": list(schemas.EstadoPedidoEnum),
+            "request": request, "form_title": "Crear Nuevo Pedido", "form_action": request.url_for("crear_pedido_submit"),
+            "pedido": form_data_repop, "estados_posibles": list(schemas.EstadoPedidoEnum),
             "today_date_iso": py_date.today().isoformat(), "errors": errors
         }, status_code=422)
     except ValidationError as e:
         return templates.TemplateResponse("form_pedido.html", {
-            "request": request, "form_title": "Crear Nuevo Pedido",
-            "form_action": request.url_for("crear_pedido_submit"), "pedido": form_data_repop,
-            "estados_posibles": list(schemas.EstadoPedidoEnum),
+            "request": request, "form_title": "Crear Nuevo Pedido", "form_action": request.url_for("crear_pedido_submit"),
+            "pedido": form_data_repop, "estados_posibles": list(schemas.EstadoPedidoEnum),
             "today_date_iso": py_date.today().isoformat(), "errors": e.errors()
         }, status_code=422)
 
@@ -285,11 +256,10 @@ async def crear_pedido_submit(
                                    proveedor=pedido_data.proveedor, estado=pedido_data.estado)
         return RedirectResponse(url=request.url_for("detalle_pedido_ruta", pedido_id=pedido.id), status_code=303)
     except Exception as e:
-        errors.append({"loc": ["general"], "msg": f"Error inesperado al guardar el pedido: {e}"})
+        errors.append({"loc": ["general"], "msg": f"Error inesperado: {e}"})
         return templates.TemplateResponse("form_pedido.html", {
-            "request": request, "form_title": "Crear Nuevo Pedido",
-            "form_action": request.url_for("crear_pedido_submit"), "pedido": form_data_repop,
-            "estados_posibles": list(schemas.EstadoPedidoEnum),
+            "request": request, "form_title": "Crear Nuevo Pedido", "form_action": request.url_for("crear_pedido_submit"),
+            "pedido": form_data_repop, "estados_posibles": list(schemas.EstadoPedidoEnum),
             "today_date_iso": py_date.today().isoformat(), "errors": errors
         }, status_code=500)
 
@@ -297,8 +267,7 @@ async def crear_pedido_submit(
 async def editar_pedido_form(request: Request, pedido_id: int, db: Session = Depends(get_db_session_fastapi)):
     pedido = crud.obtener_pedido(db, pedido_id=pedido_id)
     if not pedido:
-        raise HTTPException(status_code=404, detail=f"Pedido con ID {pedido_id} no encontrado")
-    from datetime import date as py_date
+        raise HTTPException(status_code=404, detail="Pedido no encontrado")
     return templates.TemplateResponse("form_pedido.html", {
         "request": request, "form_title": f"Editar Pedido #{pedido.id}",
         "form_action": request.url_for("editar_pedido_submit", pedido_id=pedido_id),
@@ -315,98 +284,198 @@ async def editar_pedido_submit(
     errors = []
     pedido_original = crud.obtener_pedido(db, pedido_id=pedido_id)
     if not pedido_original:
-        raise HTTPException(status_code=404, detail=f"Pedido con ID {pedido_id} no encontrado para actualizar")
+        raise HTTPException(status_code=404, detail="Pedido no encontrado para actualizar")
 
-    from datetime import date as py_date
     fecha_pedido_obj: Optional[py_date] = None
     form_data_repop = {"id": pedido_id, "fecha_pedido_str_form": fecha_pedido_str, "proveedor": proveedor, "estado_str_form": estado_str}
 
-
-    try:
-        fecha_pedido_obj = py_date.fromisoformat(fecha_pedido_str)
-    except ValueError:
-        errors.append({"loc": ["fecha_pedido"], "msg": "Formato de fecha inválido. Use YYYY-MM-DD."})
+    try: fecha_pedido_obj = py_date.fromisoformat(fecha_pedido_str)
+    except ValueError: errors.append({"loc": ["fecha_pedido"], "msg": "Formato de fecha inválido. Use YYYY-MM-DD."})
 
     if errors:
         return templates.TemplateResponse("form_pedido.html", {
             "request": request, "form_title": f"Editar Pedido #{pedido_id}",
             "form_action": request.url_for("editar_pedido_submit", pedido_id=pedido_id),
-            "pedido": form_data_repop,
-            "estados_posibles": list(schemas.EstadoPedidoEnum),
-            "today_date_iso": fecha_pedido_str,
-            "errors": errors
+            "pedido": form_data_repop, "estados_posibles": list(schemas.EstadoPedidoEnum),
+            "today_date_iso": fecha_pedido_str, "errors": errors
         }, status_code=422)
 
     try:
         estado_enum_val = schemas.EstadoPedidoEnum[estado_str.upper()]
-        pedido_data_update = schemas.PedidoUpdate(
-            fecha_pedido=fecha_pedido_obj,
-            proveedor=proveedor,
-            estado=estado_enum_val
-        )
+        pedido_data_update = schemas.PedidoUpdate(fecha_pedido=fecha_pedido_obj, proveedor=proveedor, estado=estado_enum_val)
     except KeyError:
         errors.append({"loc": ["estado"], "msg": "Valor de estado no válido."})
         return templates.TemplateResponse("form_pedido.html", {
             "request": request, "form_title": f"Editar Pedido #{pedido_id}",
             "form_action": request.url_for("editar_pedido_submit", pedido_id=pedido_id),
-            "pedido": form_data_repop,
-            "estados_posibles": list(schemas.EstadoPedidoEnum),
-            "today_date_iso": fecha_pedido_str,
-            "errors": errors
+            "pedido": form_data_repop, "estados_posibles": list(schemas.EstadoPedidoEnum),
+            "today_date_iso": fecha_pedido_str, "errors": errors
         }, status_code=422)
     except ValidationError as e:
         return templates.TemplateResponse("form_pedido.html", {
             "request": request, "form_title": f"Editar Pedido #{pedido_id}",
             "form_action": request.url_for("editar_pedido_submit", pedido_id=pedido_id),
-            "pedido": form_data_repop,
-            "estados_posibles": list(schemas.EstadoPedidoEnum),
-            "today_date_iso": fecha_pedido_str,
-            "errors": e.errors()
+            "pedido": form_data_repop, "estados_posibles": list(schemas.EstadoPedidoEnum),
+            "today_date_iso": fecha_pedido_str, "errors": e.errors()
         }, status_code=422)
 
     try:
         update_data_dict = pedido_data_update.dict(exclude_unset=True)
-        if proveedor == "":
-            update_data_dict['proveedor'] = None
+        if proveedor == "": update_data_dict['proveedor'] = None
         elif proveedor is None and 'proveedor' not in update_data_dict and pedido_original.proveedor is not None:
              update_data_dict['proveedor'] = None
 
         if not update_data_dict:
             return RedirectResponse(url=request.url_for("detalle_pedido_ruta", pedido_id=pedido_id), status_code=303)
-
         crud.actualizar_pedido(db, pedido_id=pedido_id, datos_actualizacion=update_data_dict)
         return RedirectResponse(url=request.url_for("detalle_pedido_ruta", pedido_id=pedido_id), status_code=303)
     except Exception as e:
-        errors.append({"loc": ["general"], "msg": f"Error inesperado al actualizar el pedido: {e}"})
+        errors.append({"loc": ["general"], "msg": f"Error inesperado: {e}"})
         return templates.TemplateResponse("form_pedido.html", {
             "request": request, "form_title": f"Editar Pedido #{pedido_id}",
             "form_action": request.url_for("editar_pedido_submit", pedido_id=pedido_id),
-            "pedido": form_data_repop,
-            "estados_posibles": list(schemas.EstadoPedidoEnum),
-            "today_date_iso": fecha_pedido_str,
-            "errors": errors
+            "pedido": form_data_repop, "estados_posibles": list(schemas.EstadoPedidoEnum),
+            "today_date_iso": fecha_pedido_str, "errors": errors
         }, status_code=500)
 
 @app.get("/pedidos/{pedido_id}/eliminar/", name="eliminar_pedido_confirm_form")
 async def eliminar_pedido_confirm_form(request: Request, pedido_id: int, db: Session = Depends(get_db_session_fastapi)):
     pedido = crud.obtener_pedido(db, pedido_id=pedido_id)
     if not pedido:
-        raise HTTPException(status_code=404, detail=f"Pedido con ID {pedido_id} no encontrado")
+        raise HTTPException(status_code=404, detail="Pedido no encontrado")
     return templates.TemplateResponse("confirmar_eliminacion_pedido.html", {"request": request, "pedido": pedido, "title": f"Confirmar Eliminación Pedido #{pedido.id}"})
 
 @app.post("/pedidos/{pedido_id}/eliminar/", name="eliminar_pedido_submit")
 async def eliminar_pedido_submit(request: Request, pedido_id: int, db: Session = Depends(get_db_session_fastapi)):
-    pedido_a_eliminar = crud.obtener_pedido(db, pedido_id=pedido_id)
-    if not pedido_a_eliminar:
-        raise HTTPException(status_code=404, detail=f"Pedido con ID {pedido_id} no encontrado para eliminar")
+    if not crud.obtener_pedido(db, pedido_id=pedido_id):
+        raise HTTPException(status_code=404, detail="Pedido no encontrado para eliminar")
     try:
         crud.eliminar_pedido(db, pedido_id=pedido_id)
         return RedirectResponse(url=request.url_for("listar_todos_pedidos"), status_code=303)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error al eliminar el pedido: {e}")
 
+# --- CRUD DetallesPedido (Ítems de Pedido) ---
+
+@app.get("/pedidos/{pedido_id}/items/nuevo/", name="crear_detalle_pedido_form")
+async def crear_detalle_pedido_form(request: Request, pedido_id: int, db: Session = Depends(get_db_session_fastapi)):
+    pedido = crud.obtener_pedido(db, pedido_id=pedido_id)
+    if not pedido:
+        raise HTTPException(status_code=404, detail=f"Pedido con ID {pedido_id} no encontrado.")
+
+    if pedido.estado != models.EstadoPedido.PENDIENTE:
+        raise HTTPException(status_code=403, detail=f"No se pueden añadir ítems a un pedido que no esté en estado '{models.EstadoPedido.PENDIENTE.value}'. Estado actual: {pedido.estado.value}")
+
+    medicamentos_disponibles = crud.obtener_medicamentos(db, limit=1000)
+
+    return templates.TemplateResponse("form_detalle_pedido.html", {
+        "request": request,
+        "form_title": f"Añadir Ítem al Pedido #{pedido.id}",
+        "form_action": request.url_for("crear_detalle_pedido_submit", pedido_id=pedido_id),
+        "pedido_id": pedido_id,
+        "medicamentos_disponibles": medicamentos_disponibles,
+        "errors": None,
+        "detalle_data": None
+    })
+
+@app.post("/pedidos/{pedido_id}/items/nuevo/", name="crear_detalle_pedido_submit")
+async def crear_detalle_pedido_submit(
+    request: Request,
+    pedido_id: int,
+    medicamento_id: int = Form(...),
+    cantidad_cajas_pedidas: int = Form(...),
+    precio_unitario_compra_caja: Optional[float] = Form(None),
+    db: Session = Depends(get_db_session_fastapi)
+):
+    pedido = crud.obtener_pedido(db, pedido_id=pedido_id)
+    if not pedido:
+        raise HTTPException(status_code=404, detail=f"Pedido con ID {pedido_id} no encontrado.")
+    if pedido.estado != models.EstadoPedido.PENDIENTE:
+        raise HTTPException(status_code=403, detail="No se pueden añadir ítems a este pedido (estado no es Pendiente).")
+
+    errors = []
+    form_data_repop = {
+        "medicamento_id": medicamento_id,
+        "cantidad_cajas_pedidas": cantidad_cajas_pedidas,
+        "precio_unitario_compra_caja": precio_unitario_compra_caja
+    }
+
+    if not crud.obtener_medicamento(db, medicamento_id=medicamento_id):
+        errors.append({"loc": ["medicamento_id"], "msg": "El medicamento seleccionado no es válido."})
+
+    if cantidad_cajas_pedidas <= 0:
+         errors.append({"loc": ["cantidad_cajas_pedidas"], "msg": "La cantidad de cajas debe ser positiva."})
+
+    if errors:
+        medicamentos_disponibles = crud.obtener_medicamentos(db, limit=1000)
+        return templates.TemplateResponse("form_detalle_pedido.html", {
+            "request": request, "form_title": f"Añadir Ítem al Pedido #{pedido_id}",
+            "form_action": request.url_for("crear_detalle_pedido_submit", pedido_id=pedido_id),
+            "pedido_id": pedido_id, "medicamentos_disponibles": medicamentos_disponibles,
+            "detalle_data": form_data_repop,
+            "errors": errors
+        }, status_code=422)
+
+    try:
+        detalle_data_schema = schemas.DetallePedidoCreate(**form_data_repop)
+    except ValidationError as e:
+        medicamentos_disponibles = crud.obtener_medicamentos(db, limit=1000)
+        return templates.TemplateResponse("form_detalle_pedido.html", {
+            "request": request, "form_title": f"Añadir Ítem al Pedido #{pedido_id}",
+            "form_action": request.url_for("crear_detalle_pedido_submit", pedido_id=pedido_id),
+            "pedido_id": pedido_id, "medicamentos_disponibles": medicamentos_disponibles,
+            "detalle_data": form_data_repop,
+            "errors": e.errors()
+        }, status_code=422)
+
+    try:
+        crud.agregar_detalle_pedido(
+            db=db, pedido_id=pedido_id, medicamento_id=detalle_data_schema.medicamento_id,
+            cantidad_cajas_pedidas=detalle_data_schema.cantidad_cajas_pedidas,
+            precio_unitario_compra_caja=detalle_data_schema.precio_unitario_compra_caja
+        )
+        return RedirectResponse(url=request.url_for("detalle_pedido_ruta", pedido_id=pedido_id), status_code=303)
+    except Exception as e:
+        errors.append({"loc": ["general"], "msg": f"Error inesperado al añadir el ítem: {e}"})
+        medicamentos_disponibles = crud.obtener_medicamentos(db, limit=1000)
+        return templates.TemplateResponse("form_detalle_pedido.html", {
+            "request": request, "form_title": f"Añadir Ítem al Pedido #{pedido_id}",
+            "form_action": request.url_for("crear_detalle_pedido_submit", pedido_id=pedido_id),
+            "pedido_id": pedido_id, "medicamentos_disponibles": medicamentos_disponibles,
+            "detalle_data": form_data_repop,
+            "errors": errors
+        }, status_code=500)
+
+@app.post("/pedidos/{pedido_id}/items/{detalle_id}/eliminar/", name="eliminar_detalle_pedido_submit")
+async def eliminar_detalle_pedido_submit(
+    request: Request,
+    pedido_id: int,
+    detalle_id: int,
+    db: Session = Depends(get_db_session_fastapi)
+):
+    pedido = crud.obtener_pedido(db, pedido_id=pedido_id)
+    if not pedido:
+        raise HTTPException(status_code=404, detail=f"Pedido con ID {pedido_id} no encontrado.")
+    if pedido.estado != models.EstadoPedido.PENDIENTE:
+        # Idealmente, este chequeo también debería estar en la lógica de la plantilla para no mostrar el botón.
+        raise HTTPException(status_code=403, detail="No se pueden eliminar ítems de este pedido (estado no es Pendiente).")
+
+    detalle_a_eliminar = crud.obtener_detalle_pedido(db, detalle_id=detalle_id)
+    if not detalle_a_eliminar or detalle_a_eliminar.pedido_id != pedido_id:
+        raise HTTPException(status_code=404, detail=f"Ítem de pedido con ID {detalle_id} no encontrado o no pertenece al pedido {pedido_id}.")
+
+    try:
+        eliminado = crud.eliminar_detalle_pedido(db, detalle_id=detalle_id)
+        if not eliminado:
+            raise HTTPException(status_code=500, detail=f"No se pudo eliminar el ítem de pedido ID {detalle_id}.")
+
+        return RedirectResponse(url=request.url_for("detalle_pedido_ruta", pedido_id=pedido_id), status_code=303)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error inesperado al eliminar el ítem del pedido: {e}")
+
+
 # Esta ruta debe ir DESPUÉS de las rutas CRUD de pedidos para evitar conflictos
-@app.get("/pedidos/{pedido_id}/", name="detalle_pedido_ruta") # Renombrada para evitar conflicto con la variable 'detalle_pedido'
+@app.get("/pedidos/{pedido_id}/", name="detalle_pedido_ruta")
 async def detalle_pedido_ruta(request: Request, pedido_id: int, db: Session = Depends(get_db_session_fastapi)):
     pedido = crud.obtener_pedido(db, pedido_id=pedido_id)
     if not pedido:
@@ -418,9 +487,10 @@ async def detalle_pedido_ruta(request: Request, pedido_id: int, db: Session = De
         "costo_total": costo_total, "title": f"Detalle Pedido #{pedido.id}"
     })
 
+
 if __name__ == "__main__":
     print("Para ejecutar esta aplicación web, use el comando:")
     print("uvicorn gestion_medicamentos.main_web:app --reload --port 8000")
     print(f"Asegúrese de estar en el directorio raíz del repositorio ('{os.path.dirname(current_dir)}') al ejecutar uvicorn.")
 
-
+[end of gestion_medicamentos/main_web.py]

--- a/gestion_medicamentos/web/templates/detalle_pedido.html
+++ b/gestion_medicamentos/web/templates/detalle_pedido.html
@@ -29,10 +29,22 @@
             <tr>
                 <td>{{ detalle.id }}</td>
                 <td>{{ detalle.medicamento_id }}</td>
-                <td>{{ detalle.medicamento.nombre if detalle.medicamento else 'Desconocido' }}</td> {# Asume que el objeto medicamento está cargado o se carga aquí #}
+                <td>{{ detalle.medicamento.nombre if detalle.medicamento else 'Desconocido' }}</td>
                 <td>{{ detalle.cantidad_cajas_pedidas }}</td>
                 <td>{{ "%.2f" | format(detalle.precio_unitario_compra_caja) if detalle.precio_unitario_compra_caja is not none else 'N/A' }}</td>
                 <td>{{ "%.2f" | format(detalle.subtotal_detalle) }}</td>
+                <td>
+                    {% if pedido.estado.name == 'PENDIENTE' %}
+                    <form method="post" action="{{ url_for('eliminar_detalle_pedido_submit', pedido_id=pedido.id, detalle_id=detalle.id) }}" style="display: inline;">
+                        <button type="submit" onclick="return confirm('¿Está seguro de que desea eliminar este ítem del pedido?');"
+                                style="background-color: #ff6b6b; color: white; border: none; padding: 5px 10px; cursor: pointer; border-radius: 3px; font-size: 0.9em;">
+                            Eliminar Ítem
+                        </button>
+                    </form>
+                    {% else %}
+                    N/A
+                    {% endif %}
+                </td>
             </tr>
             {% endfor %}
         </tbody>
@@ -43,8 +55,10 @@
 
 <div style="margin-top: 30px;">
     <a href="{{ url_for('editar_pedido_form', pedido_id=pedido.id) }}" style="background-color: #f0ad4e; color: white; padding: 10px 15px; text-decoration: none; border-radius: 4px; margin-right: 10px;">Editar Encabezado Pedido</a>
+    {% if pedido.estado.name == 'PENDIENTE' %} {# Solo permitir añadir ítems si el pedido está pendiente #}
+    <a href="{{ url_for('crear_detalle_pedido_form', pedido_id=pedido.id) }}" style="background-color: #5cb85c; color: white; padding: 10px 15px; text-decoration: none; border-radius: 4px; margin-right: 10px;">Añadir Ítem al Pedido</a>
+    {% endif %}
     <a href="{{ url_for('eliminar_pedido_confirm_form', pedido_id=pedido.id) }}" style="background-color: #d9534f; color: white; padding: 10px 15px; text-decoration: none; border-radius: 4px;">Eliminar Pedido</a>
-    {# Aquí podríamos añadir un enlace para "Añadir Ítem al Pedido" en el futuro #}
 </div>
 
 <p style="margin-top: 20px;"><a href="{{ url_for('listar_todos_pedidos') }}">Volver a la lista de pedidos</a></p>

--- a/gestion_medicamentos/web/templates/form_detalle_pedido.html
+++ b/gestion_medicamentos/web/templates/form_detalle_pedido.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+
+{% block title %}Añadir Ítem al Pedido #{{ pedido_id }} - Gestor de Medicamentos{% endblock %}
+
+{% block content %}
+<h2>Añadir Ítem al Pedido #{{ pedido_id }}</h2>
+
+<form method="post" action="{{ url_for('crear_detalle_pedido_submit', pedido_id=pedido_id) }}">
+    <div>
+        <label for="medicamento_id">Medicamento:</label>
+        <select id="medicamento_id" name="medicamento_id" required>
+            <option value="">Seleccione un medicamento...</option>
+            {% for med in medicamentos_disponibles %}
+            <option value="{{ med.id }}">{{ med.nombre }} ({{ med.marca if med.marca else 'N/A' }} - {{ med.unidades_por_caja }} uds/caja)</option>
+            {% endfor %}
+        </select>
+    </div>
+
+    <div style="margin-top: 10px;">
+        <label for="cantidad_cajas_pedidas">Cantidad de Cajas Pedidas:</label>
+        <input type="number" id="cantidad_cajas_pedidas" name="cantidad_cajas_pedidas" value="1" required min="1">
+    </div>
+
+    <div style="margin-top: 10px;">
+        <label for="precio_unitario_compra_caja">Precio de Compra por Caja (Opcional):</label>
+        <input type="number" id="precio_unitario_compra_caja" name="precio_unitario_compra_caja" step="0.01" min="0">
+        <small>Si se deja vacío, no se registrará un precio específico para este ítem en el pedido.</small>
+    </div>
+
+    <div style="margin-top: 20px;">
+        <button type="submit">Añadir Ítem al Pedido</button>
+        <a href="{{ url_for('detalle_pedido_ruta', pedido_id=pedido_id) }}" style="margin-left: 10px;">Cancelar y Volver al Pedido</a>
+    </div>
+</form>
+
+{% if errors %}
+    <div style="margin-top: 20px; color: red;">
+        <h4>Errores de validación:</h4>
+        <ul>
+            {% for error in errors %}
+                <li>
+                    {% if error.loc|length > 1 %}
+                        {{ error.loc[1] }}
+                    {% elif error.loc %}
+                        {{ error.loc[0] }}
+                    {% else %}
+                        General
+                    {% endif %}
+                    : {{ error.msg }}
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
Se implementa la funcionalidad para añadir y eliminar ítems (DetallesPedido) _a pedidos existentes a través de la interfaz web FastAPI, siempre que el _pedido se encuentre en estado 'Pendiente'.

Nuevas funcionalidades y cambios:
- Schemas Pydantic para DetallesPedido (`DetallePedidoCreate`, `DetallePedidoSchema`) revisados y actualizados para incluir la información del medicamento asociado al mostrar detalles.
- Creada plantilla `form_detalle_pedido.html` para el formulario de añadir un nuevo ítem a un pedido. Incluye un selector de medicamentos.
- Implementadas rutas GET y POST para añadir nuevos ítems a un pedido existente (`/pedidos/{pedido_id}/items/nuevo/`):
    - Verifica que el pedido esté en estado 'Pendiente'.
    - Valida los datos del formulario (medicamento, cantidad, precio opcional).
    - Llama a `crud.agregar_detalle_pedido()`.
    - Redirige al detalle del pedido.
- Implementada ruta POST para eliminar un ítem específico de un pedido (`/pedidos/{pedido_id}/items/{detalle_id}/eliminar/`):
    - Verifica que el pedido esté en estado 'Pendiente'.
    - Verifica que el ítem pertenezca al pedido.
    - Llama a `crud.eliminar_detalle_pedido()`.
    - Redirige al detalle del pedido.
- Actualizada plantilla `detalle_pedido.html`:
    - Se añade un botón "Añadir Ítem al Pedido" (visible si el pedido está pendiente).
    - Se añade un botón "Eliminar Ítem" en cada fila de la tabla de ítems (visible si el pedido está pendiente), con confirmación JavaScript.
- El archivo `main_web.py` fue reescrito para asegurar la correcta inserción y orden de las nuevas rutas, manteniendo las funcionalidades anteriores.