### PR TITLE
Fix: Corregir nombre de parámetro en CRUD para creación de medicamento

### DIFF
--- a/gestion_medicamentos/app/crud.py
+++ b/gestion_medicamentos/app/crud.py
@@ -12,7 +12,7 @@ from typing import List, Optional, Type # Para type hints
 
 # --- Funciones CRUD para Medicamento ---
 
-def crear_medicamento(db: Session, nombre: str, marca: Optional[str], unidades_por_caja: int, precio_referencia: Optional[float] = None) -> models.Medicamento:
+def crear_medicamento(db: Session, nombre: str, marca: Optional[str], unidades_por_caja: int, precio_por_caja_referencia: Optional[float] = None) -> models.Medicamento:
     """
     Crea un nuevo registro de medicamento en la base de datos.
     """
@@ -20,7 +20,7 @@ def crear_medicamento(db: Session, nombre: str, marca: Optional[str], unidades_p
         nombre=nombre,
         marca=marca,
         unidades_por_caja=unidades_por_caja,
-        precio_por_caja_referencia=precio_referencia
+        precio_por_caja_referencia=precio_por_caja_referencia # Nombre de parámetro corregido
     )
     db.add(db_medicamento)
     db.commit()


### PR DESCRIPTION
Se soluciona el error `TypeError: crear_medicamento() got an unexpected keyword argument 'precio_por_caja_referencia'`.

En la función `crear_medicamento` dentro de `app/crud.py`, el parámetro para el precio ha sido renombrado de `precio_referencia` a `precio_por_caja_referencia`. Esto alinea el nombre del parámetro con el utilizado en el schema Pydantic (`schemas.MedicamentoCreate`) y el modelo SQLAlchemy (`models.Medicamento`), asegurando que los datos del formulario se pasen correctamente al crear un nuevo medicamento con precio desde la interfaz web.