### PR TITLE
Feat: Implementar CRUD web para Lotes de Stock

### DIFF
--- a/gestion_medicamentos/app/schemas.py
+++ b/gestion_medicamentos/app/schemas.py
@@ -28,19 +28,30 @@ class MedicamentoSchema(MedicamentoBase):
 
 # --- LoteStock Schemas ---
 class LoteStockBase(BaseModel):
-    medicamento_id: int
+    # medicamento_id no se incluye aquí porque vendrá de la URL al crear/editar lotes para un medicamento específico.
+    # Se añadirá en la lógica CRUD si es necesario pasarlo al modelo SQLAlchemy.
     cantidad_cajas: int
     unidades_por_caja_lote: int
-    fecha_compra_lote: date # Hacerla opcional si el modelo tiene default? Modelo tiene default.
-    fecha_vencimiento_lote: date
+    fecha_compra_lote: Optional[date] = None # El modelo SQL tiene default=func.current_date()
+    fecha_vencimiento_lote: date # Esta sí es obligatoria al crear un lote
     precio_compra_lote_por_caja: Optional[float] = None
 
 class LoteStockCreate(LoteStockBase):
-    fecha_compra_lote: Optional[date] = None # Coincide con el default del modelo SQL
+    # Este schema se usará para validar los datos del formulario.
+    # medicamento_id se pasará por separado a la función crud.
+    pass
 
-class LoteStockSchema(LoteStockBase):
+class LoteStockUpdate(BaseModel): # Usar BaseModel para flexibilidad total en actualización
+    cantidad_cajas: Optional[int] = None
+    unidades_por_caja_lote: Optional[int] = None
+    fecha_compra_lote: Optional[date] = None
+    fecha_vencimiento_lote: Optional[date] = None
+    precio_compra_lote_por_caja: Optional[float] = None
+
+class LoteStockSchema(LoteStockBase): # Hereda los campos de LoteStockBase
     id: int
-    # medicamento: MedicamentoSchema # Descomentar si es necesario en respuestas
+    medicamento_id: int # Incluir para referencia al mostrar
+    # medicamento: Optional[MedicamentoSchema] = None # Para mostrar info del medicamento al que pertenece, si se carga la relación
 
     class Config:
         orm_mode = True

--- a/gestion_medicamentos/web/templates/confirmar_eliminacion_lote.html
+++ b/gestion_medicamentos/web/templates/confirmar_eliminacion_lote.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block title %}Confirmar Eliminación Lote - Gestor de Medicamentos{% endblock %}
+
+{% block content %}
+<h2>Confirmar Eliminación de Lote de Stock</h2>
+
+{% if lote and medicamento_info %}
+    <p>¿Está seguro de que desea eliminar el siguiente lote de stock del medicamento <strong>{{ medicamento_info.nombre }}</strong>?</p>
+    <p><strong>ID Lote:</strong> {{ lote.id }}</p>
+    <p><strong>Cantidad de Cajas:</strong> {{ lote.cantidad_cajas }}</p>
+    <p><strong>Unidades/Caja (Lote):</strong> {{ lote.unidades_por_caja_lote }}</p>
+    <p><strong>Fecha de Compra:</strong> {{ lote.fecha_compra_lote.strftime('%d/%m/%Y') }}</p>
+    <p><strong>Fecha de Vencimiento:</strong> {{ lote.fecha_vencimiento_lote.strftime('%d/%m/%Y') }}</p>
+
+    <p style="color: red; font-weight: bold;">Esta acción no se puede deshacer.</p>
+
+    <form method="post" action="{{ url_for('eliminar_lote_submit', lote_id=lote.id) }}" style="margin-top: 20px;">
+        <button type="submit" style="background-color: #d9534f; color: white; border: none; padding: 10px 15px; cursor: pointer; border-radius: 4px;">Sí, Eliminar Lote</button>
+        <a href="{{ url_for('detalle_medicamento', medicamento_id=medicamento_info.id) }}" style="margin-left: 10px; text-decoration: none; background-color: #ccc; color: #333; padding: 10px 15px; border-radius: 4px;">Cancelar</a>
+    </form>
+{% else %}
+    <p>No se ha especificado un lote para eliminar o no se encontró la información necesaria.</p>
+    <p><a href="{{ url_for('listar_todos_medicamentos') }}">Volver a la lista de medicamentos</a></p>
+{% endif %}
+
+{% endblock %}

--- a/gestion_medicamentos/web/templates/detalle_medicamento.html
+++ b/gestion_medicamentos/web/templates/detalle_medicamento.html
@@ -28,6 +28,7 @@
                 <th>Fecha de Vencimiento</th>
                 <th>Precio Compra/Caja (Lote)</th>
                 <th>Activo (No Vencido)</th>
+                <th>Acciones</th>
             </tr>
         </thead>
         <tbody>
@@ -41,6 +42,10 @@
                 <td>{{ lote.fecha_vencimiento_lote.strftime('%d/%m/%Y') }}</td>
                 <td>{{ lote.precio_compra_lote_por_caja if lote.precio_compra_lote_por_caja is not none else 'N/A' }}</td>
                 <td>{% if lote.fecha_vencimiento_lote >= today_date %}Sí{% else %}No{% endif %}</td>
+                <td>
+                    <a href="{{ url_for('editar_lote_form', lote_id=lote.id) }}" style="font-size: 0.9em; margin-right: 5px;">Editar</a>
+                    <a href="{{ url_for('eliminar_lote_confirm_form', lote_id=lote.id) }}" style="font-size: 0.9em; color: #d9534f;">Eliminar</a>
+                </td>
             </tr>
             {% endfor %}
         </tbody>
@@ -48,6 +53,10 @@
 {% else %}
     <p>No hay lotes de stock registrados para este medicamento.</p>
 {% endif %}
+
+<div style="margin-top: 20px;">
+     <a href="{{ url_for('crear_lote_form', medicamento_id=medicamento.id) }}" style="background-color: #5cb85c; color: white; padding: 10px 15px; text-decoration: none; border-radius: 4px; margin-right: 10px;">Añadir Nuevo Lote de Stock</a>
+</div>
 
 <div style="margin-top: 30px;">
     <a href="{{ url_for('editar_medicamento_form', medicamento_id=medicamento.id) }}" style="background-color: #f0ad4e; color: white; padding: 10px 15px; text-decoration: none; border-radius: 4px; margin-right: 10px;">Editar Medicamento</a>

--- a/gestion_medicamentos/web/templates/form_lote.html
+++ b/gestion_medicamentos/web/templates/form_lote.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+
+{% block title %}{{ form_title }} - Gestor de Medicamentos{% endblock %}
+
+{% block content %}
+<h2>{{ form_title }}</h2>
+{% if medicamento_info %}
+    <p><strong>Medicamento:</strong> {{ medicamento_info.nombre }} (ID: {{ medicamento_info.id }})</p>
+{% endif %}
+
+<form method="post" action="{{ form_action }}">
+    <div>
+        <label for="cantidad_cajas">Cantidad de Cajas:</label>
+        <input type="number" id="cantidad_cajas" name="cantidad_cajas"
+               value="{{ lote.cantidad_cajas if lote else '1' }}"
+               required min="1">
+    </div>
+
+    <div style="margin-top: 10px;">
+        <label for="unidades_por_caja_lote">Unidades por Caja para este Lote:</label>
+        <input type="number" id="unidades_por_caja_lote" name="unidades_por_caja_lote"
+               value="{{ lote.unidades_por_caja_lote if lote else (medicamento_info.unidades_por_caja if medicamento_info else '') }}"
+               required min="1">
+        <small>Por defecto, las unidades/caja del medicamento, pero puede ser específico para este lote.</small>
+    </div>
+
+    <div style="margin-top: 10px;">
+        <label for="fecha_compra_lote">Fecha de Compra del Lote (YYYY-MM-DD):</label>
+        <input type="date" id="fecha_compra_lote" name="fecha_compra_lote"
+               value="{{ lote.fecha_compra_lote.strftime('%Y-%m-%d') if lote and lote.fecha_compra_lote else today_date_iso }}"
+               required>
+         <small>Si se deja vacío, se usará la fecha actual al guardar (para creación).</small>
+    </div>
+
+    <div style="margin-top: 10px;">
+        <label for="fecha_vencimiento_lote">Fecha de Vencimiento del Lote (YYYY-MM-DD):</label>
+        <input type="date" id="fecha_vencimiento_lote" name="fecha_vencimiento_lote"
+               value="{{ lote.fecha_vencimiento_lote.strftime('%Y-%m-%d') if lote and lote.fecha_vencimiento_lote else '' }}"
+               required>
+    </div>
+
+    <div style="margin-top: 10px;">
+        <label for="precio_compra_lote_por_caja">Precio de Compra por Caja para este Lote (Opcional):</label>
+        <input type="number" id="precio_compra_lote_por_caja" name="precio_compra_lote_por_caja"
+               value="{{ lote.precio_compra_lote_por_caja if lote and lote.precio_compra_lote_por_caja is not none else '' }}"
+               step="0.01" min="0">
+    </div>
+
+    <div style="margin-top: 20px;">
+        <button type="submit">Guardar Lote</button>
+        <a href="{{ url_for('detalle_medicamento', medicamento_id=(medicamento_info.id if medicamento_info else (lote.medicamento_id if lote else 0))) }}"
+           style="margin-left: 10px;">Cancelar y Volver al Medicamento</a>
+    </div>
+</form>
+
+{% if errors %}
+    <div style="margin-top: 20px; color: red;">
+        <h4>Errores de validación:</h4>
+        <ul>
+            {% for error in errors %}
+                <li>
+                    {% if error.loc|length > 1 %}
+                        {{ error.loc[1] }}
+                    {% elif error.loc %}
+                        {{ error.loc[0] }}
+                    {% else %}
+                        General
+                    {% endif %}
+                    : {{ error.msg }}
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
Se añade la funcionalidad completa de Crear, Leer, Actualizar y Eliminar (CRUD) para los Lotes de Stock a través de la interfaz web FastAPI, asociados a un medicamento específico.

Nuevas funcionalidades y cambios:
- Revisados y actualizados Schemas Pydantic para LoteStock (`LoteStockBase`, `LoteStockCreate`, `LoteStockUpdate`, `LoteStockSchema`) en `app/schemas.py`.
- Creada plantilla de formulario `form_lote.html` reutilizable para crear y editar lotes, mostrando información del medicamento asociado.
- Implementadas rutas GET y POST para añadir nuevos lotes de stock a un medicamento (`/medicamentos/{medicamento_id}/lotes/nuevo/`), incluyendo validación de fechas y cantidades.
- Implementadas rutas GET y POST para editar lotes de stock existentes (`/lotes/{lote_id}/editar/`), con pre-rellenado de formulario y validación.
- Creada plantilla `confirmar_eliminacion_lote.html`.
- Implementadas rutas GET y POST para eliminar lotes de stock (`/lotes/{lote_id}/eliminar/`) con página de confirmación.
- Actualizada plantilla `detalle_medicamento.html` para incluir:
    - Botón "Añadir Nuevo Lote de Stock".
    - Enlaces "Editar" y "Eliminar" para cada lote listado.
- El archivo `main_web.py` fue reescrito/actualizado para asegurar la correcta inserción y orden de las nuevas rutas CRUD para lotes.