### PR TITLE
Feat: Añadir enlace 'Stock' a la navegación principal web

### DIFF
--- a/gestion_medicamentos/web/templates/base.html
+++ b/gestion_medicamentos/web/templates/base.html
@@ -30,6 +30,7 @@
                 <li><a href="{{ url_for('root') }}">Inicio</a></li>
                 <li><a href="{{ url_for('listar_todos_medicamentos') }}">Medicamentos</a></li>
                 <li><a href="{{ url_for('listar_todos_pedidos') }}">Pedidos</a></li>
+                <li><a href="{{ url_for('listar_todos_medicamentos') }}">Stock</a></li> {# Nuevo enlace a Stock #}
             </ul>
         </nav>
     </header>


### PR DESCRIPTION
Se añade un enlace 'Stock' a la barra de navegación en la plantilla `base.html` de la interfaz web.

Este enlace dirige al usuario a la página de listado de medicamentos (`/medicamentos/`), desde donde puede acceder al detalle de cada medicamento para ver y gestionar sus lotes de stock.