### PR TITLE
Fix: Resuelve TemplateSyntaxError por tag 'now'

### DIFF
--- a/gestion_medicamentos/main_web.py
+++ b/gestion_medicamentos/main_web.py
@@ -31,6 +31,7 @@ templates_dir = os.path.join(current_dir, "web", "templates")
 templates = Jinja2Templates(directory=templates_dir)
 templates.env.globals['py_date'] = py_date # Hacer py_date (datetime.date) accesible en todas las plantillas
 templates.env.globals['len'] = len # Hacer len() accesible
+templates.env.globals['current_year'] = py_date.today().year # Añadir año actual
 
 # Montar directorio estático
 static_dir = os.path.join(current_dir, "web", "static")

--- a/gestion_medicamentos/web/templates/base.html
+++ b/gestion_medicamentos/web/templates/base.html
@@ -38,7 +38,7 @@
     </main>
 
     <footer class="footer">
-        <p>&copy; {% now 'local', '%Y' %} Gestor de Medicamentos. Desarrollado con la ayuda de Google Jules.</p>
+        <p>&copy; {{ current_year }} Gestor de Medicamentos. Desarrollado con la ayuda de Google Jules.</p>
     </footer>
 
     {% block scripts_extra %}{% endblock %}


### PR DESCRIPTION
Reemplaza el tag `{% now 'local', '%Y' %}` (específico de Django) por una variable global `{{ current_year }}` en `base.html`. La variable `current_year` se añade al entorno global de Jinja2 en `main_web.py`.

Esto corrige el error `jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'now'`.