### PR TITLE
Fix: Intenta resolver NoMatchFound para archivos estáticos

### DIFF
--- a/gestion_medicamentos/web/templates/base.html
+++ b/gestion_medicamentos/web/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Gestor de Medicamentos{% endblock %}</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Montserrat:wght@700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ request.app.url_path_for('static', path='css/style.css') }}">
     {% block head_extra %}{% endblock %}
 </head>
 <body>


### PR DESCRIPTION
Cambia el método de generación de URL para archivos estáticos en `base.html` de `url_for('static', filename='...')` a
`request.app.url_path_for('static', path='...')`.

Esto se hace para intentar solucionar un error `starlette.routing.NoMatchFound` relacionado con la ruta de los archivos CSS.