### PR TITLE
Fix: Corrige TypeError en base.html para clase activa de nav

### DIFF
--- a/gestion_medicamentos/web/templates/base.html
+++ b/gestion_medicamentos/web/templates/base.html
@@ -13,12 +13,12 @@
         <h1>Gestor de Medicamentos</h1>
         <nav>
             <ul>
-                <li><a href="{{ url_for('root') }}" class="{{ 'active' if request.endpoint == 'root' else '' }}">Inicio</a></li>
-                <li><a href="{{ url_for('listar_todos_medicamentos') }}" class="{{ 'active' if 'medicamento' in request.endpoint else '' }}">Medicamentos</a></li>
-                <li><a href="{{ url_for('listar_todos_pedidos') }}" class="{{ 'active' if 'pedido' in request.endpoint else '' }}">Pedidos</a></li>
+                <li><a href="{{ url_for('root') }}" class="{{ 'active' if request.url.path == url_for('root') else '' }}">Inicio</a></li>
+                <li><a href="{{ url_for('listar_todos_medicamentos') }}" class="{{ 'active' if request.url.path.startswith(url_for('listar_todos_medicamentos')) else '' }}">Medicamentos</a></li>
+                <li><a href="{{ url_for('listar_todos_pedidos') }}" class="{{ 'active' if request.url.path.startswith(url_for('listar_todos_pedidos')) else '' }}">Pedidos</a></li>
                 {# El enlace de Stock duplicado se puede eliminar o redirigir si es una sección diferente #}
                 {# <li><a href="{{ url_for('listar_todos_medicamentos') }}">Stock</a></li> #}
-                <li><a href="{{ url_for('reporte_costos_mensuales') }}" class="{{ 'active' if 'reporte' in request.endpoint else '' }}">Reportes</a></li>
+                <li><a href="{{ url_for('reporte_costos_mensuales') }}" class="{{ 'active' if request.url.path == url_for('reporte_costos_mensuales') else '' }}">Reportes</a></li>
             </ul>
         </nav>
     </header>


### PR DESCRIPTION
Modifica la lógica en `base.html` para determinar el enlace activo en la barra de navegación. En lugar de usar `request.endpoint` (que causaba un TypeError porque no es un string iterable en el contexto de plantillas de FastAPI/Starlette), se usa `request.url.path` comparado con `url_for('nombre_ruta')`.

- Para enlaces directos (Inicio, Reportes), se usa `request.url.path == url_for(...)`.
- Para secciones con subrutas (Medicamentos, Pedidos), se usa `request.url.path.startswith(url_for(...))` para mantener activo el enlace principal de la sección.