### PR TITLE
Fix: Resuelve TypeError con url_for en Jinja startswith

### DIFF
--- a/gestion_medicamentos/web/templates/base.html
+++ b/gestion_medicamentos/web/templates/base.html
@@ -13,12 +13,12 @@
         <h1>Gestor de Medicamentos</h1>
         <nav>
             <ul>
-                <li><a href="{{ url_for('root') }}" class="{{ 'active' if request.url.path == url_for('root') else '' }}">Inicio</a></li>
-                <li><a href="{{ url_for('listar_todos_medicamentos') }}" class="{{ 'active' if request.url.path.startswith(url_for('listar_todos_medicamentos')) else '' }}">Medicamentos</a></li>
-                <li><a href="{{ url_for('listar_todos_pedidos') }}" class="{{ 'active' if request.url.path.startswith(url_for('listar_todos_pedidos')) else '' }}">Pedidos</a></li>
+                <li><a href="{{ url_for('root') }}" class="{{ 'active' if request.url.path == str(url_for('root')) else '' }}">Inicio</a></li>
+                <li><a href="{{ url_for('listar_todos_medicamentos') }}" class="{{ 'active' if request.url.path.startswith(str(url_for('listar_todos_medicamentos'))) else '' }}">Medicamentos</a></li>
+                <li><a href="{{ url_for('listar_todos_pedidos') }}" class="{{ 'active' if request.url.path.startswith(str(url_for('listar_todos_pedidos'))) else '' }}">Pedidos</a></li>
                 {# El enlace de Stock duplicado se puede eliminar o redirigir si es una sección diferente #}
                 {# <li><a href="{{ url_for('listar_todos_medicamentos') }}">Stock</a></li> #}
-                <li><a href="{{ url_for('reporte_costos_mensuales') }}" class="{{ 'active' if request.url.path == url_for('reporte_costos_mensuales') else '' }}">Reportes</a></li>
+                <li><a href="{{ url_for('reporte_costos_mensuales') }}" class="{{ 'active' if request.url.path == str(url_for('reporte_costos_mensuales')) else '' }}">Reportes</a></li>
             </ul>
         </nav>
     </header>


### PR DESCRIPTION
Convierte explícitamente el resultado de `url_for()` a `str` antes de usarlo con `startswith()` o `==` en las plantillas Jinja2 (`base.html`).

El objeto URL de Starlette devuelto por `url_for()` no es directamente compatible con métodos de string como `startswith`, causando un `TypeError`. Envolverlo con `str()` soluciona este problema.