### PR TITLE
Fix: Usar request.url_for en plantillas base de Jinja2

### DIFF
--- a/gestion_medicamentos/web/templates/base.html
+++ b/gestion_medicamentos/web/templates/base.html
@@ -13,12 +13,12 @@
         <h1>Gestor de Medicamentos</h1>
         <nav>
             <ul>
-                <li><a href="{{ url_for('root') }}" class="{{ 'active' if request.url.path == str(url_for('root')) else '' }}">Inicio</a></li>
-                <li><a href="{{ url_for('listar_todos_medicamentos') }}" class="{{ 'active' if request.url.path.startswith(str(url_for('listar_todos_medicamentos'))) else '' }}">Medicamentos</a></li>
-                <li><a href="{{ url_for('listar_todos_pedidos') }}" class="{{ 'active' if request.url.path.startswith(str(url_for('listar_todos_pedidos'))) else '' }}">Pedidos</a></li>
+                <li><a href="{{ request.url_for('root') }}" class="{{ 'active' if request.url.path == str(request.url_for('root')) else '' }}">Inicio</a></li>
+                <li><a href="{{ request.url_for('listar_todos_medicamentos') }}" class="{{ 'active' if request.url.path.startswith(str(request.url_for('listar_todos_medicamentos'))) else '' }}">Medicamentos</a></li>
+                <li><a href="{{ request.url_for('listar_todos_pedidos') }}" class="{{ 'active' if request.url.path.startswith(str(request.url_for('listar_todos_pedidos'))) else '' }}">Pedidos</a></li>
                 {# El enlace de Stock duplicado se puede eliminar o redirigir si es una sección diferente #}
                 {# <li><a href="{{ url_for('listar_todos_medicamentos') }}">Stock</a></li> #}
-                <li><a href="{{ url_for('reporte_costos_mensuales') }}" class="{{ 'active' if request.url.path == str(url_for('reporte_costos_mensuales')) else '' }}">Reportes</a></li>
+                <li><a href="{{ request.url_for('reporte_costos_mensuales') }}" class="{{ 'active' if request.url.path == str(request.url_for('reporte_costos_mensuales')) else '' }}">Reportes</a></li>
             </ul>
         </nav>
     </header>


### PR DESCRIPTION
Corrige el AttributeError 'str object has no attribute jinja_pass_arg' al asegurar que url_for se llame a través del objeto request en las plantillas de FastAPI.

Esto se aplicó a los enlaces de navegación en base.html para la generación de href y la lógica condicional de clases CSS.