### PR TITLE
Fix: Resolver UndefinedError para str en plantillas Jinja2

### DIFF
--- a/gestion_medicamentos/main_web.py
+++ b/gestion_medicamentos/main_web.py
@@ -31,6 +31,7 @@ templates_dir = os.path.join(current_dir, "web", "templates")
 templates = Jinja2Templates(directory=templates_dir)
 templates.env.globals['py_date'] = py_date # Hacer py_date (datetime.date) accesible en todas las plantillas
 templates.env.globals['len'] = len # Hacer len() accesible
+templates.env.globals['str'] = str # Hacer str() accesible
 templates.env.globals['current_year'] = py_date.today().year # Añadir año actual
 
 # Montar directorio estático

--- a/gestion_medicamentos/web/templates/base.html
+++ b/gestion_medicamentos/web/templates/base.html
@@ -13,12 +13,12 @@
         <h1>Gestor de Medicamentos</h1>
         <nav>
             <ul>
-                <li><a href="{{ request.url_for('root') }}" class="{{ 'active' if request.url.path == str(request.url_for('root')) else '' }}">Inicio</a></li>
-                <li><a href="{{ request.url_for('listar_todos_medicamentos') }}" class="{{ 'active' if request.url.path.startswith(str(request.url_for('listar_todos_medicamentos'))) else '' }}">Medicamentos</a></li>
-                <li><a href="{{ request.url_for('listar_todos_pedidos') }}" class="{{ 'active' if request.url.path.startswith(str(request.url_for('listar_todos_pedidos'))) else '' }}">Pedidos</a></li>
+                <li><a href="{{ request.url_for('root') }}" class="{{ 'active' if request.url.path == request.url_for('root') else '' }}">Inicio</a></li>
+                <li><a href="{{ request.url_for('listar_todos_medicamentos') }}" class="{{ 'active' if request.url.path.startswith(request.url_for('listar_todos_medicamentos')) else '' }}">Medicamentos</a></li>
+                <li><a href="{{ request.url_for('listar_todos_pedidos') }}" class="{{ 'active' if request.url.path.startswith(request.url_for('listar_todos_pedidos')) else '' }}">Pedidos</a></li>
                 {# El enlace de Stock duplicado se puede eliminar o redirigir si es una sección diferente #}
                 {# <li><a href="{{ url_for('listar_todos_medicamentos') }}">Stock</a></li> #}
-                <li><a href="{{ request.url_for('reporte_costos_mensuales') }}" class="{{ 'active' if request.url.path == str(request.url_for('reporte_costos_mensuales')) else '' }}">Reportes</a></li>
+                <li><a href="{{ request.url_for('reporte_costos_mensuales') }}" class="{{ 'active' if request.url.path == request.url_for('reporte_costos_mensuales') else '' }}">Reportes</a></li>
             </ul>
         </nav>
     </header>


### PR DESCRIPTION
- Elimina la conversión explícita str() en las comparaciones de URL en base.html, confiando en la coerción de tipos.
- Añade str a los globales del entorno Jinja2 en main_web.py para asegurar su disponibilidad si es necesario.

Esto aborda el error `jinja2.exceptions.UndefinedError: 'str' is undefined` que surgía después de la corrección inicial de url_for.