### PR TITLE
Mostrar precio por unidad en vistas de medicamentos

### DIFF
--- a/gestion_medicamentos/web/templates/detalle_medicamento.html
+++ b/gestion_medicamentos/web/templates/detalle_medicamento.html
@@ -10,6 +10,13 @@
 <p><strong>Marca:</strong> {{ medicamento.marca if medicamento.marca else 'N/A' }}</p>
 <p><strong>Unidades por Caja:</strong> {{ medicamento.unidades_por_caja }}</p>
 <p><strong>Precio de Referencia por Caja:</strong> {{ medicamento.precio_por_caja_referencia if medicamento.precio_por_caja_referencia is not none else 'N/A' }}</p>
+<p><strong>Precio por Unidad de Referencia:</strong>
+    {% if precio_por_unidad is not none %}
+        {{ "%.2f €" | format(precio_por_unidad) }}
+    {% else %}
+        N/A
+    {% endif %}
+</p>
 <p><strong>Estado:</strong> <span style="font-weight: bold; color: {% if medicamento.esta_activo %}green{% else %}red{% endif %};">
     {% if medicamento.esta_activo %}Activo{% else %}En Desuso{% endif %}
 </span></p>

--- a/gestion_medicamentos/web/templates/lista_medicamentos.html
+++ b/gestion_medicamentos/web/templates/lista_medicamentos.html
@@ -14,6 +14,7 @@
                 <th>Marca</th>
                 <th>Unidades/Caja</th>
                 <th>Stock Total (Unidades Activas)</th>
+                <th>Precio/Unidad Ref.</th>
                 <th>Vencimiento Próximo (Lote)</th>
                 <th>Vencimiento Receta</th>
                 <th>Estado</th>
@@ -28,6 +29,13 @@
                 <td>{{ med_info.medicamento.marca if med_info.medicamento.marca else 'N/A' }}</td>
                 <td>{{ med_info.medicamento.unidades_por_caja }}</td>
                 <td>{{ med_info.stock_total }}</td>
+                <td class="text-right">
+                    {% if med_info.precio_por_unidad is not none %}
+                        {{ "%.2f €" | format(med_info.precio_por_unidad) }}
+                    {% else %}
+                        N/A
+                    {% endif %}
+                </td>
                 <td>{{ med_info.vencimiento_proximo.strftime('%d/%m/%Y') if med_info.vencimiento_proximo else 'N/A' }}</td>
                 <td>{{ med_info.medicamento.vencimiento_receta.strftime('%d/%m/%Y') if med_info.medicamento.vencimiento_receta else '-' }}</td>
                 <td>{% if med_info.medicamento.esta_activo %}Activo{% else %}En Desuso{% endif %}</td>

--- a/gestion_medicamentos/web/templates/vista_stock_global.html
+++ b/gestion_medicamentos/web/templates/vista_stock_global.html
@@ -15,6 +15,7 @@
                 <th>Medicamento</th>
                 <th>Marca</th>
                 <th>Estado</th>
+                <th class="text-right">Precio/Unidad Ref.</th>
                 <th class="text-right">Stock Total (Unidades)</th>
                 <th class="text-right">Valor Estimado del Stock</th>
                 <th>Acciones</th>
@@ -35,6 +36,13 @@
                         <span style="color: green;">Activo</span>
                     {% else %}
                         <span style="color: red;">En Desuso</span>
+                    {% endif %}
+                </td>
+                <td class="text-right">
+                    {% if item.precio_por_unidad_referencia is not none %}
+                        {{ "%.2f €" | format(item.precio_por_unidad_referencia) }}
+                    {% else %}
+                        N/A
                     {% endif %}
                 </td>
                 <td class="text-right">{{ item.stock_total_unidades }}</td>


### PR DESCRIPTION
- Calculado y añadido precio/unidad a las rutas de listado, detalle y stock global de medicamentos.
- Actualizadas las plantillas HTML correspondientes para mostrar este nuevo campo formateado.